### PR TITLE
fix: `LinearRegression` predictions are now correct in case of under determined systems (n < m)

### DIFF
--- a/cmnemoi_learn/regression/linear_regression.py
+++ b/cmnemoi_learn/regression/linear_regression.py
@@ -4,7 +4,7 @@ File defining a Linear Regression model.
 
 from typing import Self
 import numpy as np
-from numpy.linalg import inv
+from numpy.linalg import cond, det, inv, svd
 
 from cmnemoi_learn.regression.abstract_regressor import AbstractRegressor
 
@@ -34,7 +34,15 @@ class LinearRegression(AbstractRegressor):
         """
         self.X = self._get_inputs_with_bias_column(X)
         self.y = y
-        self.theta = inv(self.X.T @ self.X) @ (self.X.T @ self.y)
+        inputs_covariance_matrix = self.X.T @ self.X
+
+        conditionnement = cond(inputs_covariance_matrix)
+        epsilon = np.finfo(inputs_covariance_matrix.dtype).eps
+        if conditionnement >= 1 / epsilon:
+            U, S, Vh = svd(inputs_covariance_matrix)
+            inputs_covariance_matrix = np.dot(U * S, Vh)
+        
+        self.theta = inv(inputs_covariance_matrix) @ (self.X.T @ self.y)
         return self
 
     def predict(self, X: np.ndarray) -> np.ndarray:

--- a/cmnemoi_learn/regression/linear_regression.py
+++ b/cmnemoi_learn/regression/linear_regression.py
@@ -4,7 +4,7 @@ File defining a Linear Regression model.
 
 from typing import Self
 import numpy as np
-from numpy.linalg import cond, det, inv, svd
+from numpy.linalg import pinv
 
 from cmnemoi_learn.regression.abstract_regressor import AbstractRegressor
 
@@ -34,15 +34,9 @@ class LinearRegression(AbstractRegressor):
         """
         self.X = self._get_inputs_with_bias_column(X)
         self.y = y
-        inputs_covariance_matrix = self.X.T @ self.X
 
-        conditionnement = cond(inputs_covariance_matrix)
-        epsilon = np.finfo(inputs_covariance_matrix.dtype).eps
-        if conditionnement >= 1 / epsilon:
-            U, S, Vh = svd(inputs_covariance_matrix)
-            inputs_covariance_matrix = np.dot(U * S, Vh)
-        
-        self.theta = inv(inputs_covariance_matrix) @ (self.X.T @ self.y)
+        self.theta = pinv(self.X.T @ self.X) @ (self.X.T @ self.y)
+
         return self
 
     def predict(self, X: np.ndarray) -> np.ndarray:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def regression_linear_dataset() -> np.ndarray:
 @pytest.fixture
 def regression_linear_dataset_with_small_n_big_p() -> np.ndarray:
     """Regression dataset which follows a linear pattern
-    `X, y = regression_circle_dataset` to use
+    `X, y = regression_linear_dataset_with_small_n_big_p` to use
 
     Returns:
         np.ndarray: The dataset

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,33 +3,30 @@ Fixtures for unit tests
 """
 
 import numpy as np
-from sklearn.datasets import make_regression, make_circles
+from sklearn.datasets import make_regression, make_friedman2
 import pytest
 
 BIAS = 5
-NOISE = 2
 NUMBER_OF_FEATURES = 2
 NUMBER_OF_SAMPLES = 50
 RANDOM_STATE = 42
 
 
 @pytest.fixture
-def regression_circle_dataset() -> np.ndarray:
-    """Regression dataset which follows circles pattern
-    `X, y = regression_circle_dataset` to use
+def regression_friedman_dataset() -> np.ndarray:
+    """Regression dataset which follows friedman #2 problem pattern
+    `X, y = regression_friedman_dataset` to use
 
     Returns:
         np.ndarray: The dataset
     """
-    return make_circles(
-        n_samples=NUMBER_OF_SAMPLES, shuffle=False, random_state=RANDOM_STATE
-    )
+    return make_friedman2(random_state=RANDOM_STATE)
 
 
 @pytest.fixture
 def regression_linear_dataset() -> np.ndarray:
     """Regression dataset which follows a linear pattern
-    `X, y = regression_circle_dataset` to use
+    `X, y = regression_linear_dataset` to use
 
     Returns:
         np.ndarray: The dataset
@@ -45,7 +42,7 @@ def regression_linear_dataset() -> np.ndarray:
 
 
 @pytest.fixture
-def regression_linear_dataset_with_noise() -> np.ndarray:
+def regression_linear_dataset_with_small_n_big_p() -> np.ndarray:
     """Regression dataset which follows a linear pattern
     `X, y = regression_circle_dataset` to use
 
@@ -54,10 +51,9 @@ def regression_linear_dataset_with_noise() -> np.ndarray:
     """
     return make_regression(
         n_samples=NUMBER_OF_SAMPLES,
-        n_features=NUMBER_OF_FEATURES,
-        n_informative=NUMBER_OF_FEATURES,
+        n_features=NUMBER_OF_SAMPLES + 1,
+        n_informative=NUMBER_OF_SAMPLES + 1,
         bias=BIAS,
-        noise=NOISE,
         shuffle=False,
         random_state=RANDOM_STATE,
     )

--- a/tests/regression/test_linear_regression.py
+++ b/tests/regression/test_linear_regression.py
@@ -1,5 +1,5 @@
 """
-Unit tests for Linear Regression model
+Unit tests for Linear Regression model against sklearn implementation
 """
 import numpy as np
 
@@ -11,7 +11,24 @@ from cmnemoi_learn.regression.linear_regression import LinearRegression
 np.random.seed(42)
 
 
-def test_linear_predict(regression_linear_dataset) -> None:
+def test_predict_friedman_dataset(regression_friedman_dataset: np.ndarray) -> None:
+    """
+    Test `predict` against sklearn implementation.
+    """
+    X, y = regression_friedman_dataset
+    cmnemoi_model = LinearRegression()
+    cmnemoi_model = cmnemoi_model.fit(X, y)
+
+    sklearn_model = SklearnLinearRegression()
+    sklearn_model = sklearn_model.fit(X, y)
+
+    cmnemoi_prediction = cmnemoi_model.predict(X)
+    sklearn_prediction = sklearn_model.predict(X)
+
+    assert np.allclose(cmnemoi_prediction, sklearn_prediction)
+
+
+def test_predict_linear_dataset(regression_linear_dataset: np.ndarray) -> None:
     """
     Test `predict` against sklearn implementation.
     """
@@ -28,11 +45,13 @@ def test_linear_predict(regression_linear_dataset) -> None:
     assert np.allclose(cmnemoi_prediction, sklearn_prediction)
 
 
-def test_linear_with_noise_predict(regression_linear_dataset_with_noise) -> None:
+def test_predict_linear_dataset_with_small_n_big_p(
+    regression_linear_dataset_with_small_n_big_p: np.ndarray,
+) -> None:
+    """Test `predict` on a linear dataset with small `n` and big `p`
+    (underdetermined system)
     """
-    Test `predict` against sklearn implementation.
-    """
-    X, y = regression_linear_dataset_with_noise
+    X, y = regression_linear_dataset_with_small_n_big_p
     cmnemoi_model = LinearRegression()
     cmnemoi_model = cmnemoi_model.fit(X, y)
 
@@ -45,30 +64,13 @@ def test_linear_with_noise_predict(regression_linear_dataset_with_noise) -> None
     assert np.allclose(cmnemoi_prediction, sklearn_prediction)
 
 
-def test_circle_predict(regression_circle_dataset) -> None:
-    """
-    Test `predict` against sklearn implementation.
-    """
-    X, y = regression_circle_dataset
-    cmnemoi_model = LinearRegression()
-    cmnemoi_model = cmnemoi_model.fit(X, y)
-
-    sklearn_model = SklearnLinearRegression()
-    sklearn_model = sklearn_model.fit(X, y)
-
-    cmnemoi_prediction = cmnemoi_model.predict(X)
-    sklearn_prediction = sklearn_model.predict(X)
-
-    assert np.allclose(cmnemoi_prediction, sklearn_prediction)
-
-
-def test_score(regression_circle_dataset) -> None:
+def test_score(regression_friedman_dataset) -> None:
     """Test `score` method against sklearn implementation.
 
     Args:
-        regression_circle_dataset (np.ndarray): Dataset with a circle pattern.
+        regression_friedman_dataset (np.ndarray): Dataset with a friedman pattern.
     """
-    X, y = regression_circle_dataset
+    X, y = regression_friedman_dataset
     model = LinearRegression()
     model = model.fit(X, y)
 

--- a/tests/regression/test_linear_regression.py
+++ b/tests/regression/test_linear_regression.py
@@ -13,7 +13,7 @@ np.random.seed(42)
 
 def test_predict_friedman_dataset(regression_friedman_dataset: np.ndarray) -> None:
     """
-    Test `predict` against sklearn implementation.
+    Test `predict` on the Friedman #2 problem.
     """
     X, y = regression_friedman_dataset
     cmnemoi_model = LinearRegression()
@@ -30,7 +30,7 @@ def test_predict_friedman_dataset(regression_friedman_dataset: np.ndarray) -> No
 
 def test_predict_linear_dataset(regression_linear_dataset: np.ndarray) -> None:
     """
-    Test `predict` against sklearn implementation.
+    Test `predict` on a linear dataset.
     """
     X, y = regression_linear_dataset
     cmnemoi_model = LinearRegression()


### PR DESCRIPTION
Using Moore-Penrose pseudo-inverse in normal equation solution instead of the inverse, which works only if the problem is not under determined 