### PR TITLE
docs: Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,14 @@ The package will be published on PyPI at each push to the `main` branch through 
 ```bash
 python3.11 venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install cmnemoi-learn
 ```
 
 ## pyenv and poetry
 ```bash
 pyenv install 3.11
 pyenv local 3.11
-poetry install
-```
-
-## Anaconda or Miniconda
-```bash
-conda create -n cmnemoi-learn python=3.11 -y
-conda activate cmnemoi-learn
-pip install cmnemoi-learn
+poetry install cmnemoi-learn
 ```
 
 # Contributing
@@ -57,13 +50,6 @@ If you run Poetry and pyenv:
 pyenv install 3.11
 pyenv local 3.11
 poetry install --with=dev,test
-```
-
-If you run Miniconda or Anaconda: 
-```bash
-conda create -n cmnemoi-learn-dev python=3.11 -y
-conda activate cmnemoi-learn-dev
-pip install -r requirements-dev.txt
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install cmnemoi-learn
 ```bash
 pyenv install 3.11
 pyenv local 3.11
-poetry install cmnemoi-learn
+poetry add cmnemoi-learn
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -15,18 +15,10 @@ The package will be published on PyPI at each push to the `main` branch through 
 
 # Install the package
 
-## With base tools
 ```bash
 python3.11 venv .venv
 source .venv/bin/activate
 pip install cmnemoi-learn
-```
-
-## pyenv and poetry
-```bash
-pyenv install 3.11
-pyenv local 3.11
-poetry add cmnemoi-learn
 ```
 
 # Contributing


### PR DESCRIPTION
This Merge Request fixes package installation instructions : 
- Add instructions to install to actual package instead of its dependencies
- Remove instructions to install with conda or poetry